### PR TITLE
Publish vsix package to release assets

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: CI & Publish VS Code Theme
+name: CI & Publish
 
 on:
   pull_request:
@@ -46,3 +46,13 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: pnpm run publish
 
+      - name: Upload .vsix file as release asset
+        if: github.event_name == 'release' && github.event.action == 'released' && github.event.release.draft == false
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./endeavouros-dark-${{ github.ref_name }}.vsix
+          asset_name: endeavouros-dark-${{ github.ref_name }}.vsix
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/publish.yaml` file to automate the process of uploading the `.vsix` file as a release asset when a new release is published.

Changes to CI/CD workflow:

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR49-R58): Added a step to upload the `.vsix` file as a release asset when a new release is published and is not a draft.